### PR TITLE
Updated date in changelog for 1.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 - Product experiences in Web SDK
 - Carousel preview bug fix
 
-## [1.6.10] - 17 Jan, 2023
+## [1.6.10] - 17 Jan, 2024
 - Fixes a bug related to Web Inbox rendering on mobile browser
 
 ## [1.6.9] - 6 Dec, 2023


### PR DESCRIPTION
This PR updates the changelog for version 1.6.10 to reflect the correct date of the release