### PR TITLE
revert: undo ARM migration and multi-arch changes in semaphore pipelines

### DIFF
--- a/.semaphore/production-deploy.yml
+++ b/.semaphore/production-deploy.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Production-Deploy
 agent:
   machine:
-    type: s1-agent-c6g-large
+    type: s1-agent-c5-large
     os_image: ''
 blocks:
   - name: Deploy Assets
@@ -15,8 +15,8 @@ blocks:
               set -euo pipefail
               mkdir utils
               aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/utils/generate_assumed_role_creds.py utils/generate_assumed_role_creds.py
-              aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/uv/uv-aarch64-unknown-linux-gnu.tar.gz - | tar -v -xz -C utils/
-              export PATH="$PATH:$(pwd)/utils/uv-aarch64-unknown-linux-gnu"
+              aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/uv/uv-x86_64-unknown-linux-gnu.tar.gz - | tar -v -xz -C utils/
+              export PATH="$PATH:$(pwd)/utils/uv-x86_64-unknown-linux-gnu"
               uv venv prod
               source prod/bin/activate
               uv pip install argparse PyJWT requests cryptography pytablewriter pyyaml boto3   
@@ -29,5 +29,5 @@ blocks:
         - name: ProductionAccountAwsCredentials
       agent:
         machine:
-          type: s1-agent-c6g-large
+          type: s1-agent-c5-large
           os_image: ''

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Build Pipeline
 agent:
   machine:
-    type: s1-agent-t4g-micro
+    type: s1-agent-t2-micro
     os_image: ''
 blocks:
   - name: Build Assets

--- a/.semaphore/staging-deploy.yml
+++ b/.semaphore/staging-deploy.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Staging-Deploy
 agent:
   machine:
-    type: s1-agent-t4g-micro
+    type: s1-agent-t2-micro
     os_image: ''
 blocks:
   - name: Deploy Assets
@@ -19,8 +19,8 @@ blocks:
               set -euo pipefail
               mkdir utils
               aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/utils/generate_assumed_role_creds.py utils/generate_assumed_role_creds.py
-              aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/uv/uv-aarch64-unknown-linux-gnu.tar.gz - | tar -v -xz -C utils/
-              export PATH="$PATH:$(pwd)/utils/uv-aarch64-unknown-linux-gnu"
+              aws s3 cp s3://semaphore-agent-customres-semaphoredependenciess3b-okhz8b8lstnx/uv/uv-x86_64-unknown-linux-gnu.tar.gz - | tar -v -xz -C utils/
+              export PATH="$PATH:$(pwd)/utils/uv-x86_64-unknown-linux-gnu"
               uv venv prod
               source prod/bin/activate
               uv pip install argparse PyJWT requests cryptography pytablewriter pyyaml boto3   
@@ -41,5 +41,5 @@ blocks:
         - name: ProductionAccountAwsCredentials 
       agent:
         machine:
-          type: s1-agent-c6g-large
+          type: s1-agent-c5-large
           os_image: ''


### PR DESCRIPTION
## Summary
Revert all ARM (Graviton) migration changes introduced via the `update-agent-to-arm` branch.

### What is reverted
- **Agent types**: `c6g` → `c5`, `t4g` → `t2` (back to x86)
- **Binaries**: ARM variants → x86 variants (uv, Go, Node.js, JDK, etc.)
- **Docker builds**: Multi-arch `docker buildx` → original single-arch `docker build` (where applicable)
- **cfstack**: `cfstack-arm` → `cfstack` (where applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/CD infrastructure change that can break builds/deploys if the selected x86 agent images or downloaded binaries don’t match runtime expectations.
> 
> **Overview**
> Reverts Semaphore CI/CD agent selection from ARM/Graviton to x86 by switching machine types (`t4g`→`t2`, `c6g`→`c5`) across build, staging deploy, and production deploy pipelines.
> 
> Updates deploy scripts to download and use the x86_64 `uv` tarball (and PATH) instead of the aarch64 variant, keeping the rest of the S3/CloudFront deployment flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2968329b62f100ed35e9b0cb6f136e1a6a466d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline infrastructure configurations to optimize build and deployment processes across staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->