### PR TITLE
Application server key flag set

### DIFF
--- a/src/modules/webPushPrompt/prompt.js
+++ b/src/modules/webPushPrompt/prompt.js
@@ -89,7 +89,6 @@ export const processSoftPrompt = () => {
     notificationHandler.setupWebPush(displayArgs)
   }
   StorageManager.saveToLSorCookie(NOTIFICATION_PUSH_METHOD_DEFERRED, false)
-  StorageManager.saveToLSorCookie(APPLICATION_SERVER_KEY_RECEIVED, false)
 }
 
 export const parseDisplayArgs = (displayArgs) => {


### PR DESCRIPTION
### Changes

Describe the key changes in this PR with the Jira Issue reference 
- The flag was set to false in prompt.js even though the key was received and the flag was initially set as true

### Changes to Public Facing API if any 
None

Please list the impact on the public facing API if any
None

### How Has This Been Tested?

Describe the testing approach and any relevant configurations (e.g., environment, platform)
- Tested in local web app

### Checklist

- [x] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [x] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite