### PR TITLE
Dropping discarded events on requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.7.5] 30th July 2026
+- Dropping the discarded event data from requests
+
 ## [2.7.4] 14th July 2026
 - Updated the src for wzrk dialog needed for web pusbh
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-web-sdk",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "",
   "main": "dist/clevertap.js",
   "files": [

--- a/src/util/requestDispatcher.js
+++ b/src/util/requestDispatcher.js
@@ -272,7 +272,11 @@ export default class RequestDispatcher {
       return addToURL(url, 'arp', compressData(JSON.stringify(_arp), this.logger))
     }
     if (StorageManager._isLocalStorageSupported() && typeof localStorage.getItem(ARP_COOKIE) !== 'undefined' && localStorage.getItem(ARP_COOKIE) !== null) {
-      return addToURL(url, 'arp', compressData(JSON.stringify(StorageManager.readFromLSorCookie(ARP_COOKIE)), this.logger))
+      const arpData = StorageManager.readFromLSorCookie(ARP_COOKIE)
+      if (arpData) {
+        delete arpData.d_e
+      }
+      return addToURL(url, 'arp', compressData(JSON.stringify(arpData), this.logger))
     }
     return url
   }


### PR DESCRIPTION
### Changes

Describe the key changes in this PR with the Jira Issue reference 
- Dropping the d_e from arp data since it causesd url length to exceed

### Changes to Public Facing API if any 
None

Please list the impact on the public facing API if any

### How Has This Been Tested?

Describe the testing approach and any relevant configurations (e.g., environment, platform)
- Tested on local env using the account which had discarded events in it

### Checklist

- [ ] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [ ] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite