### PR TITLE
Fixed the identity error which occurs when OUL is done on parent and subdomain

### DIFF
--- a/src/util/lruCache.js
+++ b/src/util/lruCache.js
@@ -1,5 +1,8 @@
 import { StorageManager } from './storage'
-import { LRU_CACHE } from './constants'
+import { LRU_CACHE, COOKIE_EXPIRY } from './constants'
+
+// Max entries to persist in the broad-domain cookie to stay within ~4 KB cookie size limit
+const LRU_COOKIE_MAX = 10
 
 export default class LRUCache {
   #keyOrder
@@ -21,6 +24,48 @@ export default class LRUCache {
     } else {
       this.cache = {}
       this.#keyOrder = []
+    }
+
+    // Merge entries from broad-domain cookie so that identity→GUID
+    // mappings written on a sibling sub-domain are visible here.
+    this.#mergeCookieCache()
+  }
+
+  #mergeCookieCache () {
+    try {
+      const cookieData = StorageManager.readCookie(LRU_CACHE)
+      if (cookieData) {
+        const parsed = JSON.parse(cookieData)
+        if (parsed && parsed.cache) {
+          let merged = false
+          for (const entry of parsed.cache) {
+            const key = entry[0]
+            const value = entry[1]
+            if (key && value && !this.cache[key]) {
+              this.cache[key] = value
+              this.#keyOrder.push(key)
+              merged = true
+            }
+          }
+          if (merged) {
+            // Persist merged state back to localStorage and cookie
+            this.saveCacheToLS(this.cache)
+          }
+        }
+      }
+    } catch (e) {
+      // Cookie data may be malformed; ignore
+    }
+  }
+
+  #saveCacheToBroadCookie (objToArray) {
+    try {
+      // Only keep the most recent entries to stay within cookie size limits
+      const recentEntries = objToArray.slice(-LRU_COOKIE_MAX)
+      const cookieValue = JSON.stringify({ cache: recentEntries })
+      StorageManager.createBroadCookie(LRU_CACHE, cookieValue, COOKIE_EXPIRY, window.location.hostname)
+    } catch (e) {
+      // Cookie storage may fail; non-critical
     }
   }
 
@@ -62,6 +107,9 @@ export default class LRUCache {
       }
     }
     StorageManager.saveToLSorCookie(LRU_CACHE, { cache: objToArray })
+
+    // Also persist to broad-domain cookie for cross-subdomain sharing
+    this.#saveCacheToBroadCookie(objToArray)
   }
 
   getKey (value) {

--- a/src/util/lruCache.js
+++ b/src/util/lruCache.js
@@ -1,9 +1,6 @@
 import { StorageManager } from './storage'
 import { LRU_CACHE, COOKIE_EXPIRY } from './constants'
 
-// Max entries to persist in the broad-domain cookie to stay within ~4 KB cookie size limit
-const LRU_COOKIE_MAX = 10
-
 export default class LRUCache {
   #keyOrder
 
@@ -60,9 +57,7 @@ export default class LRUCache {
 
   #saveCacheToBroadCookie (objToArray) {
     try {
-      // Only keep the most recent entries to stay within cookie size limits
-      const recentEntries = objToArray.slice(-LRU_COOKIE_MAX)
-      const cookieValue = JSON.stringify({ cache: recentEntries })
+      const cookieValue = JSON.stringify({ cache: objToArray })
       StorageManager.createBroadCookie(LRU_CACHE, cookieValue, COOKIE_EXPIRY, window.location.hostname)
     } catch (e) {
       // Cookie storage may fail; non-critical


### PR DESCRIPTION
### Changes

Describe the key changes in this PR with the Jira Issue reference 
**STR:**
- User opens the website for the first time; both abc.com and xyz.abc.com has same GUID
- User does OUL on parent domain abc.com; the anonymous GUID is not assigned an identity. Same GUID on both domains
- Now the user does OUL on the parent domain abc.com; the new GUID is assigned
- User does OUL on child domain xyz.abc.com; the anonymous GUID is used and assigned an identity.
- Parent domain subdomain has a different GUID. Since the OUL on the parent domain had GUID A and the same OUL on the child domain had GUID B, the Identity Error shows up on the dashboard. 

**Changes made**
Cross-subdomain LRU cache sharing (src/util/lruCache.js)

 The identity→GUID LRU cache (WZRK_X) was stored only in localStorage, which is per-origin by browser spec. This meant arobid.com and account.arobid.com couldn't see each other's identity mappings, causing onUserLogin() on the second domain to reset the GUID and trigger an Identity Error.

 Fix: The LRU cache is now also persisted to a broad-domain cookie (via createBroadCookie). On initialization, entries from the broad cookie are merged into the local cache. This ensures identity→GUID mappings are shared across subdomains.
  

### Changes to Public Facing API if any 
None

Please list the impact on the public facing API if any
None

### How Has This Been Tested?

Describe the testing approach and any relevant configurations (e.g., environment, platform)

### Checklist

- [ ] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [ ] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite