### PR TITLE
added jira issue id to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+JIRA Issue: JIRA_TICKET_ID
 
 ### Changes
 


### PR DESCRIPTION
JIRA Issue: ONC-671

### Changes

Now in the PR description, writing the JIRA Issue ID automatically links to JIRA.
Accordingly, the PR template is updated to add the JIRA Issue.

### Changes to Public Facing API if any 

None

### How Has This Been Tested?

In this PR as well as any PR, if you write any JIRA Issue ID, it will automatically link

### Checklist

- [ ] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [ ] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite