### PR TITLE
exponential backoff retry mechanism added with unit tests

### DIFF
--- a/src/clevertap.js
+++ b/src/clevertap.js
@@ -863,12 +863,7 @@ export default class CleverTap {
     initDiscardedEventsFromStorage()
     this.#processOldValues()
     this.pageChanged()
-    const backupInterval = setInterval(() => {
-      if (this.#device.gcookie) {
-        clearInterval(backupInterval)
-        this.#request.processBackupEvents()
-      }
-    }, 3000)
+
     if (this.#isSpa) {
       // listen to click on the document and check if URL has changed.
       document.addEventListener('click', this.#boundCheckPageChanged)

--- a/src/clevertap.js
+++ b/src/clevertap.js
@@ -863,7 +863,7 @@ export default class CleverTap {
     initDiscardedEventsFromStorage()
     this.#processOldValues()
     this.pageChanged()
-
+    this.#request.processBackupEvents()
     if (this.#isSpa) {
       // listen to click on the document and check if URL has changed.
       document.addEventListener('click', this.#boundCheckPageChanged)

--- a/src/modules/request.js
+++ b/src/modules/request.js
@@ -1,5 +1,5 @@
-import { SCOOKIE_PREFIX, CAMP_COOKIE_NAME, CLEAR, EVT_PUSH, EV_COOKIE, FIRE_PUSH_UNREGISTERED, LCOOKIE_NAME, PUSH_SUBSCRIPTION_DATA, WEBPUSH_LS_KEY } from '../util/constants'
-import { isObjectEmpty, isValueValid, removeUnsupportedChars, safeJSONParse } from '../util/datatypes'
+import { SCOOKIE_PREFIX, CAMP_COOKIE_NAME, CLEAR, EVT_PUSH, EV_COOKIE, FIRE_PUSH_UNREGISTERED, LCOOKIE_NAME, PUSH_SUBSCRIPTION_DATA, WEBPUSH_LS_KEY, OPTOUT_COOKIE_ENDSWITH } from '../util/constants'
+import { isObjectEmpty, isValueValid, removeUnsupportedChars, safeJSONParse, isString } from '../util/datatypes'
 import { getNow } from '../util/datetime'
 import { compressData } from '../util/encoder'
 import RequestDispatcher from '../util/requestDispatcher'
@@ -18,6 +18,7 @@ export default class RequestManager {
   #isPersonalisationActive
   #clearCookie = false
   processingBackup = false
+  processedBackup = false
 
   constructor ({ logger, account, device, session, isPersonalisationActive }) {
     this.#logger = logger
@@ -33,11 +34,16 @@ export default class RequestManager {
 
   /**
  * Unified backup processing method
- * @param {boolean} oulOnly - If true, process only OUL requests. If false, process all non-fired requests.
+ * @param {boolean} oulOnly - If true, process only OUL requests. If false, process all backup requests.
  */
   processBackupEvents (oulOnly = false) {
     const backupMap = StorageManager.readFromLSorCookie(LCOOKIE_NAME)
     if (typeof backupMap === 'undefined' || backupMap === null) {
+      return
+    }
+
+    if (this.processingBackup || this.processedBackup) {
+      this.#logger.debug('Backup processing already in progress or completed..')
       return
     }
 
@@ -46,10 +52,6 @@ export default class RequestManager {
     for (const idx in backupMap) {
       if (backupMap.hasOwnProperty(idx)) {
         const backupEvent = backupMap[idx]
-
-        if (typeof backupEvent.fired !== 'undefined') {
-          continue
-        }
 
         const isOULRequest = StorageManager.isBackupOUL(parseInt(idx))
         const shouldProcess = oulOnly ? isOULRequest : true
@@ -64,13 +66,15 @@ export default class RequestManager {
               backupEvent.q = backupEvent.q + '&s=' + session.s
             }
             RequestDispatcher.fireRequest(backupEvent.q)
+          } else {
+            this.#logger.error('Backup event is malformed.. removing from backup', backupEvent)
+            StorageManager.removeBackup(idx, this.#logger)
           }
-          backupEvent.fired = true
         }
       }
     }
-    StorageManager.saveToLSorCookie(LCOOKIE_NAME, backupMap)
     this.processingBackup = false
+    this.processedBackup = true
   }
 
   addSystemDataToObject (dataObject, ignoreTrim) {
@@ -147,6 +151,11 @@ export default class RequestManager {
       return
     }
 
+    if (this.#dropRequestDueToOptOut()) {
+      this.#logger.debug('req dropped due to optout cookie: ' + this.#device.gcookie)
+      return
+    }
+
     const now = getNow()
 
     // Get the next available request number that doesn't conflict with existing backups
@@ -184,80 +193,88 @@ export default class RequestManager {
     }
   }
 
-#getNextAvailableReqN () {
-  // Read existing backup data to check for conflicts
-  const backupMap = StorageManager.readFromLSorCookie(LCOOKIE_NAME)
+  #dropRequestDueToOptOut () {
+    if ($ct.isOptInRequest || !isValueValid(this.#device.gcookie) || !isString(this.#device.gcookie)) {
+      $ct.isOptInRequest = false
+      return false
+    }
+    return this.#device.gcookie.slice(-3) === OPTOUT_COOKIE_ENDSWITH
+  }
 
-  // Start from the current REQ_N + 1
-  let candidateReqN = $ct.globalCache.REQ_N + 1
+  #getNextAvailableReqN () {
+    // Read existing backup data to check for conflicts
+    const backupMap = StorageManager.readFromLSorCookie(LCOOKIE_NAME)
 
-  // If no backup data exists, use the candidate
-  if (!backupMap || typeof backupMap !== 'object') {
+    // Start from the current REQ_N + 1
+    let candidateReqN = $ct.globalCache.REQ_N + 1
+
+    // If no backup data exists, use the candidate
+    if (!backupMap || typeof backupMap !== 'object') {
+      return candidateReqN
+    }
+
+    // Keep incrementing until we find a request number that doesn't exist in backup
+    while (backupMap.hasOwnProperty(candidateReqN.toString())) {
+      candidateReqN++
+      this.#logger.debug(`Request number ${candidateReqN - 1} already exists in backup, trying ${candidateReqN}`)
+    }
+
+    this.#logger.debug(`Using request number: ${candidateReqN}`)
     return candidateReqN
   }
 
-  // Keep incrementing until we find a request number that doesn't exist in backup
-  while (backupMap.hasOwnProperty(candidateReqN.toString())) {
-    candidateReqN++
-    this.#logger.debug(`Request number ${candidateReqN - 1} already exists in backup, trying ${candidateReqN}`)
+  unregisterTokenForGuid (givenGUID) {
+    const payload = StorageManager.readFromLSorCookie(PUSH_SUBSCRIPTION_DATA)
+    // Send unregister event only when token is available
+    if (payload) {
+      const data = {}
+      data.type = 'data'
+      if (isValueValid(givenGUID)) {
+        data.g = givenGUID
+      }
+      data.action = 'unregister'
+      data.id = this.#account.id
+
+      const obj = this.#session.getSessionCookieObject()
+
+      data.s = obj.s // session cookie
+      const compressedData = compressData(JSON.stringify(data), this.#logger)
+
+      let pageLoadUrl = this.#account.dataPostURL
+      pageLoadUrl = addToURL(pageLoadUrl, 'type', 'data')
+      pageLoadUrl = addToURL(pageLoadUrl, 'd', compressedData)
+      RequestDispatcher.fireRequest(pageLoadUrl, true)
+      StorageManager.saveToLSorCookie(FIRE_PUSH_UNREGISTERED, false)
+    }
+    // REGISTER TOKEN
+    this.registerToken(payload)
   }
 
-  this.#logger.debug(`Using request number: ${candidateReqN}`)
-  return candidateReqN
-}
-
-unregisterTokenForGuid (givenGUID) {
-  const payload = StorageManager.readFromLSorCookie(PUSH_SUBSCRIPTION_DATA)
-  // Send unregister event only when token is available
-  if (payload) {
-    const data = {}
-    data.type = 'data'
-    if (isValueValid(givenGUID)) {
-      data.g = givenGUID
-    }
-    data.action = 'unregister'
-    data.id = this.#account.id
-
-    const obj = this.#session.getSessionCookieObject()
-
-    data.s = obj.s // session cookie
-    const compressedData = compressData(JSON.stringify(data), this.#logger)
-
+  registerToken (payload) {
+    if (!payload) return
+    // add gcookie etc to the payload
+    payload = this.addSystemDataToObject(payload, true)
+    payload = JSON.stringify(payload)
     let pageLoadUrl = this.#account.dataPostURL
     pageLoadUrl = addToURL(pageLoadUrl, 'type', 'data')
-    pageLoadUrl = addToURL(pageLoadUrl, 'd', compressedData)
-    RequestDispatcher.fireRequest(pageLoadUrl, true)
-    StorageManager.saveToLSorCookie(FIRE_PUSH_UNREGISTERED, false)
+    pageLoadUrl = addToURL(pageLoadUrl, 'd', compressData(payload, this.#logger))
+    RequestDispatcher.fireRequest(pageLoadUrl)
+    // set in localstorage
+    StorageManager.save(WEBPUSH_LS_KEY, 'ok')
   }
-  // REGISTER TOKEN
-  this.registerToken(payload)
-}
 
-registerToken (payload) {
-  if (!payload) return
-  // add gcookie etc to the payload
-  payload = this.addSystemDataToObject(payload, true)
-  payload = JSON.stringify(payload)
-  let pageLoadUrl = this.#account.dataPostURL
-  pageLoadUrl = addToURL(pageLoadUrl, 'type', 'data')
-  pageLoadUrl = addToURL(pageLoadUrl, 'd', compressData(payload, this.#logger))
-  RequestDispatcher.fireRequest(pageLoadUrl)
-  // set in localstorage
-  StorageManager.save(WEBPUSH_LS_KEY, 'ok')
-}
+  processEvent (data) {
+    this.#addToLocalEventMap(data.evtName)
+    data = this.addSystemDataToObject(data, undefined)
+    this.addFlags(data)
+    data[CAMP_COOKIE_NAME] = getCampaignObjForLc()
+    const compressedData = compressData(JSON.stringify(data), this.#logger)
+    let pageLoadUrl = this.#account.dataPostURL
+    pageLoadUrl = addToURL(pageLoadUrl, 'type', EVT_PUSH)
+    pageLoadUrl = addToURL(pageLoadUrl, 'd', compressedData)
 
-processEvent (data) {
-  this.#addToLocalEventMap(data.evtName)
-  data = this.addSystemDataToObject(data, undefined)
-  this.addFlags(data)
-  data[CAMP_COOKIE_NAME] = getCampaignObjForLc()
-  const compressedData = compressData(JSON.stringify(data), this.#logger)
-  let pageLoadUrl = this.#account.dataPostURL
-  pageLoadUrl = addToURL(pageLoadUrl, 'type', EVT_PUSH)
-  pageLoadUrl = addToURL(pageLoadUrl, 'd', compressedData)
-
-  this.saveAndFireRequest(pageLoadUrl, $ct.blockRequest, false, data.evtName)
-}
+    this.saveAndFireRequest(pageLoadUrl, $ct.blockRequest, false, data.evtName)
+  }
 
   #addToLocalEventMap (evtName) {
     if (StorageManager._isLocalStorageSupported()) {

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -74,6 +74,8 @@ export const CUSTOM_CT_ID_PREFIX = '_w_'
 export const BLOCK_REQUEST_COOKIE = 'WZRK_BLOCK'
 export const ENABLE_TV_CONTROLS = 'WZRK_TV_CONTROLS'
 export const ENCRYPTION_KEY_NAME = 'WZRK_ENCRYPTION_KEY'
+export const INITIAL_RETRY_DELAY_MS = 1000
+export const MAX_RETRY_DELAY_MS = 30 * 60 * 1000 // 30 minutes
 
 // Flag key for optional sub-domain profile isolation
 export const ISOLATE_COOKIE = 'WZRK_ISOLATE_SD'

--- a/src/util/requestDispatcher.js
+++ b/src/util/requestDispatcher.js
@@ -89,24 +89,27 @@ export default class RequestDispatcher {
    * max delay has been used, the following retry starts at initial delay.
    * A 50%-100% jitter is applied to avoid retrying requests simultaneously.
    */
-  static #scheduleRetryViaFetch (encryptedUrl, originalUrl, retryAttempt = 0) {
-    const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(2, retryAttempt), MAX_RETRY_DELAY_MS)
-    const delay = Math.floor(retryDelay * (0.5 + Math.random() * 0.5))
-    const nextRetryAttempt = retryDelay === MAX_RETRY_DELAY_MS ? 0 : retryAttempt + 1
-    this.logger.debug(`Retrying request in ${delay}ms: ${encryptedUrl}`)
-    setTimeout(() => {
-      this.handleFetchResponse(encryptedUrl, originalUrl, nextRetryAttempt)
-    }, delay)
-  }
 
-  static #scheduleRetryViaJSONP (url, retryAttempt = 0) {
+  static #scheduleRetry (url, retryAttempt = 0, run) {
     const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(2, retryAttempt), MAX_RETRY_DELAY_MS)
     const delay = Math.floor(retryDelay * (0.5 + Math.random() * 0.5))
     const nextRetryAttempt = retryDelay === MAX_RETRY_DELAY_MS ? 0 : retryAttempt + 1
     this.logger.debug(`Retrying request in ${delay}ms: ${url}`)
-    setTimeout(() => {
-      this.#retryViaJSONP(url, nextRetryAttempt)
-    }, delay)
+    setTimeout(() => run(nextRetryAttempt), delay)
+  }
+
+  static #scheduleRetryViaFetch (encryptedUrl, originalUrl, retryAttempt = 0) {
+    this.#scheduleRetry(
+      encryptedUrl, retryAttempt,
+      (nextRetryAttempt) => this.handleFetchResponse(encryptedUrl, originalUrl, nextRetryAttempt)
+    )
+  }
+
+  static #scheduleRetryViaJSONP (url, retryAttempt = 0) {
+    this.#scheduleRetry(
+      url, retryAttempt,
+      (nextRetryAttempt) => this.#retryViaJSONP(url, nextRetryAttempt)
+    )
   }
 
   /**

--- a/src/util/requestDispatcher.js
+++ b/src/util/requestDispatcher.js
@@ -1,9 +1,9 @@
 
-import { ARP_COOKIE, MAX_TRIES, OPTOUT_COOKIE_ENDSWITH, USEIP_KEY, MAX_DELAY_FREQUENCY, PUSH_DELAY_MS, WZRK_FETCH, CT_EIT_FALLBACK, MUTE_EXPIRY_KEY } from './constants'
-import { isString, isValueValid } from './datatypes'
+import { ARP_COOKIE, MAX_TRIES, USEIP_KEY, MAX_DELAY_FREQUENCY, PUSH_DELAY_MS, WZRK_FETCH, CT_EIT_FALLBACK, MUTE_EXPIRY_KEY, INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS, OPTOUT_COOKIE_ENDSWITH } from './constants'
+import { isValueValid, isString } from './datatypes'
 import { compressData } from './encoder'
 import { StorageManager, $ct, isMuted, getMuteExpiry } from './storage'
-import { addToURL } from './url'
+import { addToURL, getURLParam } from './url'
 import encryptionInTransitInstance from './security/encryptionInTransit'
 
 export default class RequestDispatcher {
@@ -63,7 +63,7 @@ export default class RequestDispatcher {
    * Used when EIT is rejected by the backend.
    * @param {string} url - The URL to send via JSONP
    */
-  static #retryViaJSONP (url) {
+  static #retryViaJSONP (url, retryAttempt = 0) {
     // Clean up any existing callback scripts
     var ctCbScripts = document.getElementsByClassName('ct-jp-cb')
     while (ctCbScripts[0] && ctCbScripts[0].parentNode) {
@@ -77,8 +77,36 @@ export default class RequestDispatcher {
     s.setAttribute('class', 'ct-jp-cb')
     s.setAttribute('rel', 'nofollow')
     s.async = true
+    s.onerror = () => {
+      this.#scheduleRetryViaJSONP(url, retryAttempt)
+    }
     document.getElementsByTagName('head')[0].appendChild(s)
     this.logger.debug('EIT fallback: req snt via JSONP -> url: ' + url)
+  }
+
+  /**
+   * Retries failed transport requests with an exponential delay. Once the
+   * max delay has been used, the following retry starts at initial delay.
+   * A 50%-100% jitter is applied to avoid retrying requests simultaneously.
+   */
+  static #scheduleRetryViaFetch (encryptedUrl, originalUrl, retryAttempt = 0) {
+    const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(2, retryAttempt), MAX_RETRY_DELAY_MS)
+    const delay = Math.floor(retryDelay * (0.5 + Math.random() * 0.5))
+    const nextRetryAttempt = retryDelay === MAX_RETRY_DELAY_MS ? 0 : retryAttempt + 1
+    this.logger.debug(`Retrying request in ${delay}ms: ${encryptedUrl}`)
+    setTimeout(() => {
+      this.handleFetchResponse(encryptedUrl, originalUrl, nextRetryAttempt)
+    }, delay)
+  }
+
+  static #scheduleRetryViaJSONP (url, retryAttempt = 0) {
+    const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(2, retryAttempt), MAX_RETRY_DELAY_MS)
+    const delay = Math.floor(retryDelay * (0.5 + Math.random() * 0.5))
+    const nextRetryAttempt = retryDelay === MAX_RETRY_DELAY_MS ? 0 : retryAttempt + 1
+    this.logger.debug(`Retrying request in ${delay}ms: ${url}`)
+    setTimeout(() => {
+      this.#retryViaJSONP(url, nextRetryAttempt)
+    }, delay)
   }
 
   /**
@@ -139,11 +167,15 @@ export default class RequestDispatcher {
     // Check if SDK is muted (for churned accounts) - drop request silently
     if (isMuted()) {
       const muteExpiry = getMuteExpiry()
+      const rn = parseInt(getURLParam(url, 'rn'))
+      StorageManager.removeBackup(rn, this.logger)
       this.logger.debug('Request dropped - SDK is muted until ' + new Date(muteExpiry).toISOString())
       return
     }
 
     if (this.#dropRequestDueToOptOut()) {
+      const rn = parseInt(getURLParam(url, 'rn'))
+      StorageManager.removeBackup(rn, this.logger)
       this.logger.debug('req dropped due to optout cookie: ' + this.device.gcookie)
       return
     }
@@ -228,6 +260,9 @@ export default class RequestDispatcher {
           s.setAttribute('class', 'ct-jp-cb')
           s.setAttribute('rel', 'nofollow')
           s.async = true
+          s.onerror = () => {
+            this.#scheduleRetryViaJSONP(requestConfig.url)
+          }
           document.getElementsByTagName('head')[0].appendChild(s)
           this.logger.debug('req snt -> url: ' + requestConfig.url)
         } else {
@@ -317,6 +352,7 @@ export default class RequestDispatcher {
               this.#retryViaJSONP(originalUrl)
               return null // Signal that we've handled this via JSONP
             }
+
             throw new Error(`Encryption not enabled for account: ${response.statusText}`)
           }
 
@@ -332,7 +368,9 @@ export default class RequestDispatcher {
             }
           }
 
-          throw new Error(`Network response was not ok: ${response.statusText}`)
+          if (response.status >= 500 && response.status < 600) {
+            throw new Error(`Network response was not ok: ${response.statusText}`)
+          }
         }
         return response.text()
       })
@@ -399,10 +437,16 @@ export default class RequestDispatcher {
         this.logger.debug('req snt -> url: ' + encryptedUrl)
       })
       .catch((error) => {
-        if (error.message && error.message.includes('EIT decryption failed')) {
-          this.logger.error('EIT decryption failed', error)
-          // Safely ignore the response payload and proceed without applying server changes
-          return
+        if (error.message) {
+          if (error.message.includes('EIT decryption failed')) {
+            this.logger.error('EIT decryption failed', error)
+            // Safely ignore the response payload and proceed without applying server changes
+            return
+          } else if (error.message.includes('Network response was not ok')) {
+            this.logger.error('Network response was not ok', error)
+            this.#scheduleRetryViaFetch(encryptedUrl, originalUrl, retryCount)
+            return
+          }
         }
         this.logger.error('Fetch error:', error)
       })

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -1,3 +1,13 @@
+const decode = function (s) {
+  let replacement = s.replace(/\+/g, ' ') // Regex for replacing addition symbol with a space
+  try {
+    replacement = decodeURIComponent(replacement)
+  } catch (e) {
+    // eat
+  }
+  return replacement
+}
+
 export const getURLParams = (url) => {
   const urlParams = {}
   const idx = url.indexOf('?')
@@ -5,17 +15,7 @@ export const getURLParams = (url) => {
   if (idx > 1) {
     const uri = url.substring(idx + 1)
     let match
-    const pl = /\+/g // Regex for replacing addition symbol with a space
     const search = /([^&=]+)=?([^&]*)/g
-    const decode = function (s) {
-      let replacement = s.replace(pl, ' ')
-      try {
-        replacement = decodeURIComponent(replacement)
-      } catch (e) {
-        // eat
-      }
-      return replacement
-    }
     match = search.exec(uri)
     while (match) {
       urlParams[decode(match[1])] = decode(match[2])
@@ -23,6 +23,12 @@ export const getURLParams = (url) => {
     }
   }
   return urlParams
+}
+
+export const getURLParam = (url, param) => {
+  if (url === '' || param === '' || !url.includes(param)) return ''
+  const paramValue = url.split(`${param}=`)[1].split('&')[0]
+  return decode(paramValue)
 }
 
 export const getDomain = (url) => {

--- a/src/util/url.js
+++ b/src/util/url.js
@@ -26,8 +26,10 @@ export const getURLParams = (url) => {
 }
 
 export const getURLParam = (url, param) => {
-  if (url === '' || param === '' || !url.includes(param)) return ''
-  const paramValue = url.split(`${param}=`)[1].split('&')[0]
+  if (url === '' || param === '') return ''
+  const paramPrefix = url.includes(`?${param}=`) ? `?${param}=` : `&${param}=`
+  if (!url.includes(paramPrefix)) return ''
+  const paramValue = url.split(paramPrefix)[1].split('&')[0]
   return decode(paramValue)
 }
 

--- a/test/unit/modules/request.spec.js
+++ b/test/unit/modules/request.spec.js
@@ -1,0 +1,154 @@
+import 'regenerator-runtime/runtime'
+import { OPTOUT_COOKIE_ENDSWITH } from '../../../src/util/constants'
+import RequestManager from '../../../src/modules/request'
+import RequestDispatcher from '../../../src/util/requestDispatcher'
+import { StorageManager, $ct, isMuted } from '../../../src/util/storage'
+
+jest.enableAutomock().unmock('../../../src/modules/request').unmock('../../../src/util/constants')
+  .unmock('../../../src/util/datatypes')
+
+const buildRequestManager = (device = {}) => new RequestManager({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    wzrkError: {}
+  },
+  account: { id: 'acc1', dataPostURL: 'https://x.com/a' },
+  device: { gcookie: null, ...device },
+  session: { getSessionCookieObject: jest.fn().mockReturnValue({ s: 's1' }) },
+  isPersonalisationActive: () => false
+})
+
+describe('modules/request', function () {
+  let requestManager
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    requestManager = buildRequestManager()
+
+    Object.assign($ct, {
+      offline: false,
+      delayEvents: false,
+      blockRequest: false,
+      isOptInRequest: false,
+      globalCache: { REQ_N: 0, RESP_N: 0 }
+    })
+
+    window.isOULInProgress = false
+
+    StorageManager.readFromLSorCookie.mockReturnValue(null)
+    isMuted.mockReturnValue(false)
+    RequestDispatcher.fireRequest = jest.fn()
+  })
+
+  describe('saveAndFireRequest - opt out handling', () => {
+    test('should drop the request and not save/fire it when the gcookie ends with the opt-out suffix', () => {
+      requestManager = buildRequestManager({ gcookie: '123' + OPTOUT_COOKIE_ENDSWITH })
+
+      requestManager.saveAndFireRequest('http://x.com?d=abc', false, false, 'evt')
+
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+      expect(StorageManager.backupEvent).not.toHaveBeenCalled()
+    })
+
+    test('should not drop the request when an opt-in is in progress, and should reset the opt-in flag afterwards', () => {
+      $ct.isOptInRequest = true
+      requestManager = buildRequestManager({ gcookie: '123' + OPTOUT_COOKIE_ENDSWITH })
+
+      requestManager.saveAndFireRequest('http://x.com?d=abc', false, false, 'evt')
+
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalled()
+      expect($ct.isOptInRequest).toBe(false)
+    })
+
+    test('should fire the request as normal when the gcookie does not end with the opt-out suffix', () => {
+      requestManager = buildRequestManager({ gcookie: 'abc123' })
+
+      requestManager.saveAndFireRequest('http://x.com?d=abc', false, false, 'evt')
+
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalled()
+    })
+
+    test('should fire the request as normal when there is no gcookie yet', () => {
+      requestManager = buildRequestManager({ gcookie: null })
+
+      requestManager.saveAndFireRequest('http://x.com?d=abc', false, false, 'evt')
+
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalled()
+    })
+  })
+
+  describe('saveAndFireRequest - muted SDK', () => {
+    test('should drop the request without backing it up when the SDK is muted', () => {
+      isMuted.mockReturnValue(true)
+
+      requestManager.saveAndFireRequest('http://x.com?d=abc', false, false, 'evt')
+
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+      expect(StorageManager.backupEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('processBackupEvents', () => {
+    test('should skip processing entirely when a previous run is already in progress', () => {
+      StorageManager.readFromLSorCookie.mockReturnValue({ 1: { q: 'foo=bar' } })
+      requestManager.processingBackup = true
+
+      requestManager.processBackupEvents()
+
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+      expect(requestManager.processingBackup).toBe(true) // left untouched, previous run still owns it
+    })
+
+    test('should skip processing when backup events are already processed', () => {
+      StorageManager.readFromLSorCookie.mockReturnValue({ 1: { q: 'foo=bar' } })
+      requestManager.processedBackup = true
+
+      requestManager.processBackupEvents()
+
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+      expect(requestManager.processedBackup).toBe(true)
+    })
+
+    test('should fire backup events that have a valid query string and clear the in-progress flag', () => {
+      StorageManager.readFromLSorCookie.mockReturnValue({ 1: { q: 'foo=bar' } })
+
+      requestManager.processBackupEvents()
+
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalledWith('foo=bar')
+      expect(requestManager.processingBackup).toBe(false)
+    })
+
+    test('should remove malformed backup events (missing q) instead of retrying them forever', () => {
+      const malformedEvent = { fired: true }
+      StorageManager.readFromLSorCookie.mockReturnValue({ 1: malformedEvent })
+
+      requestManager.processBackupEvents()
+
+      expect(StorageManager.removeBackup).toHaveBeenCalledWith('1', expect.anything())
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+    })
+
+    test('should only process OUL backups when oulOnly is true', () => {
+      StorageManager.readFromLSorCookie.mockReturnValue({
+        1: { q: 'oul=1' },
+        2: { q: 'normal=1' }
+      })
+      StorageManager.isBackupOUL.mockImplementation((idx) => idx === 1)
+
+      requestManager.processBackupEvents(true)
+
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalledTimes(1)
+      expect(RequestDispatcher.fireRequest).toHaveBeenCalledWith('oul=1')
+    })
+
+    test('should do nothing when there is no backup data', () => {
+      StorageManager.readFromLSorCookie.mockReturnValue(null)
+
+      requestManager.processBackupEvents()
+
+      expect(RequestDispatcher.fireRequest).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/unit/util/requestDispatcher.spec.js
+++ b/test/unit/util/requestDispatcher.spec.js
@@ -1,9 +1,17 @@
 import 'regenerator-runtime/runtime'
-import { OPTOUT_COOKIE_ENDSWITH, CT_EIT_FALLBACK } from '../../../src/util/constants'
+import { CT_EIT_FALLBACK, INITIAL_RETRY_DELAY_MS, MAX_RETRY_DELAY_MS } from '../../../src/util/constants'
 import { compressData } from '../../../src/util/encoder'
 import RequestDispatcher from '../../../src/util/requestDispatcher'
 import { $ct, StorageManager } from '../../../src/util/storage'
 import { addToURL } from '../../../src/util/url'
+
+const flushPromises = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const OriginalHandleFetchResponse = RequestDispatcher.handleFetchResponse
 
 jest.enableAutomock().unmock('../../../src/util/requestDispatcher').unmock('../../../src/util/constants')
   .unmock('../../../src/util/datatypes')
@@ -64,17 +72,6 @@ describe('util/requestDispatcher', function () {
       // Reset encryption settings
       RequestDispatcher.enableEncryptionInTransit = false
       RequestDispatcher.enableFetchApi = false
-    })
-
-    describe('drop request due to opt out', () => {
-      test('should drop request and log in debug if optout cookie (endsWith:00) is set', () => {
-        RequestDispatcher.device = {
-          gcookie: '123' + OPTOUT_COOKIE_ENDSWITH
-        }
-
-        RequestDispatcher.fireRequest('some', true, true)
-        expect(RequestDispatcher.logger.debug).toHaveBeenCalledWith(expect.stringContaining('123:OO'))
-      })
     })
 
     describe('invalid gcookie value', () => {
@@ -193,6 +190,265 @@ describe('util/requestDispatcher', function () {
         RequestDispatcher.clearEITFallback()
 
         expect(StorageManager.remove).toHaveBeenCalledWith(CT_EIT_FALLBACK)
+      })
+    })
+  })
+
+  describe('retry mechanism', () => {
+    // Pulls the delay in ms out of a "Retrying request in <ms>ms: <url>" debug log call
+    const lastRetryDelay = () => {
+      const call = RequestDispatcher.logger.debug.mock.calls
+        .find(c => typeof c[0] === 'string' && c[0].startsWith('Retrying request in'))
+      return call ? parseInt(call[0].match(/Retrying request in (\d+)ms/)[1]) : undefined
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+
+      RequestDispatcher.handleFetchResponse = OriginalHandleFetchResponse
+
+      RequestDispatcher.logger = {
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn()
+      }
+
+      RequestDispatcher.enableEncryptionInTransit = false
+      RequestDispatcher.enableFetchApi = false
+
+      StorageManager._isLocalStorageSupported.mockReturnValue(true)
+      StorageManager.getMetaProp.mockReturnValue(false)
+      StorageManager.readFromLSorCookie.mockReturnValue(null)
+      StorageManager.read.mockReturnValue(false)
+      StorageManager.save.mockReturnValue(true)
+      StorageManager.saveToLSorCookie.mockReturnValue(true)
+
+      addToURL.mockImplementation((url, key, value) => `${url}&${key}=${value}`)
+      compressData.mockImplementation(data => data)
+
+      window.$WZRK_WR = {
+        tr: jest.fn(),
+        s: jest.fn(),
+        enableWebPush: jest.fn()
+      }
+    })
+
+    afterEach(() => {
+      jest.clearAllTimers()
+      jest.restoreAllMocks()
+      delete global.fetch
+    })
+
+    describe('JSONP retry (script tag onerror)', () => {
+      let createdScripts
+
+      beforeEach(() => {
+        RequestDispatcher.device = { gcookie: 'gc123' }
+        Object.assign($ct, {
+          blockRequest: false,
+          isOptInRequest: false,
+          globalCache: { REQ_N: 0, RESP_N: 0 }
+        })
+
+        createdScripts = []
+        document.getElementsByClassName = jest.fn().mockReturnValue([])
+        document.createElement = jest.fn().mockImplementation(() => {
+          const script = { setAttribute: jest.fn(), async: true }
+          createdScripts.push(script)
+          return script
+        })
+        document.getElementsByTagName = jest.fn().mockReturnValue([{ appendChild: jest.fn() }])
+      })
+
+      test('should attach an onerror handler on the injected script that schedules a retry', async () => {
+        RequestDispatcher.fireRequest('http://x.com?d=abc')
+        await flushPromises()
+
+        expect(createdScripts.length).toBe(1)
+        expect(typeof createdScripts[0].onerror).toBe('function')
+
+        createdScripts[0].onerror()
+        // retry is scheduled behind a delay, so no new script is injected synchronously
+        expect(createdScripts.length).toBe(1)
+
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+
+        expect(createdScripts.length).toBe(2)
+        expect(createdScripts[1].setAttribute).toHaveBeenCalledWith('src', expect.stringContaining('http://x.com?d=abc'))
+      })
+
+      test('should use a delay within the 50%-100% jitter window of the initial retry delay for the first retry', async () => {
+        RequestDispatcher.fireRequest('http://x.com?d=abc')
+        await flushPromises()
+
+        jest.spyOn(Math, 'random').mockReturnValue(0)
+        createdScripts[0].onerror()
+
+        jest.advanceTimersByTime(INITIAL_RETRY_DELAY_MS / 2 - 1)
+        expect(createdScripts.length).toBe(1)
+
+        jest.advanceTimersByTime(1)
+        expect(createdScripts.length).toBe(2)
+      })
+
+      test('should double the retry delay on each successive failure (exponential backoff)', async () => {
+        jest.spyOn(Math, 'random').mockReturnValue(0) // removes jitter randomness -> delay = retryDelay * 0.5
+
+        RequestDispatcher.fireRequest('http://x.com?d=abc')
+        await flushPromises()
+
+        const delays = []
+        for (let i = 0; i < 4; i++) {
+          RequestDispatcher.logger.debug.mockClear()
+          createdScripts[createdScripts.length - 1].onerror()
+          jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+          delays.push(lastRetryDelay())
+        }
+
+        expect(delays).toEqual([
+          INITIAL_RETRY_DELAY_MS * 0.5,
+          INITIAL_RETRY_DELAY_MS * 2 * 0.5,
+          INITIAL_RETRY_DELAY_MS * 4 * 0.5,
+          INITIAL_RETRY_DELAY_MS * 8 * 0.5
+        ])
+      })
+
+      test('should cap the retry delay at MAX_RETRY_DELAY_MS and restart from the initial delay on the following retry', async () => {
+        jest.spyOn(Math, 'random').mockReturnValue(0) // removes jitter randomness -> delay = retryDelay * 0.5
+
+        RequestDispatcher.fireRequest('http://x.com?d=abc')
+        await flushPromises()
+
+        // Enough consecutive failures for 1000 * 2^n to exceed MAX_RETRY_DELAY_MS and get capped
+        let cappedDelay
+        for (let i = 0; i < 12; i++) {
+          RequestDispatcher.logger.debug.mockClear()
+          createdScripts[createdScripts.length - 1].onerror()
+          jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+          cappedDelay = lastRetryDelay()
+        }
+        expect(cappedDelay).toBe(MAX_RETRY_DELAY_MS * 0.5)
+
+        // The very next retry after hitting the cap should restart from the initial delay
+        RequestDispatcher.logger.debug.mockClear()
+        createdScripts[createdScripts.length - 1].onerror()
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+        expect(lastRetryDelay()).toBe(INITIAL_RETRY_DELAY_MS * 0.5)
+      })
+    })
+
+    describe('JSONP fallback retry (server rejects encryption in transit)', () => {
+      let createdScripts
+
+      beforeEach(() => {
+        createdScripts = []
+        document.getElementsByClassName = jest.fn().mockReturnValue([])
+        document.createElement = jest.fn().mockImplementation(() => {
+          const script = { setAttribute: jest.fn(), async: true }
+          createdScripts.push(script)
+          return script
+        })
+        document.getElementsByTagName = jest.fn().mockReturnValue([{ appendChild: jest.fn() }])
+      })
+
+      test('should retry the original (unencrypted) url via JSONP, with its own retry-capable onerror handler', async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: false,
+          status: 402,
+          statusText: 'Payment Required',
+          headers: { get: () => null }
+        })
+
+        RequestDispatcher.handleFetchResponse('http://x.com?d=encrypted', 'http://x.com?d=original')
+        await flushPromises()
+
+        expect(createdScripts.length).toBe(1)
+        expect(createdScripts[0].setAttribute).toHaveBeenCalledWith('src', 'http://x.com?d=original')
+        expect(typeof createdScripts[0].onerror).toBe('function')
+
+        createdScripts[0].onerror()
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+
+        expect(createdScripts.length).toBe(2)
+      })
+    })
+
+    describe('Fetch retry (network errors via handleFetchResponse)', () => {
+      const failedResponse = (status = 500, statusText = 'Internal Server Error') => ({
+        ok: false,
+        status,
+        statusText,
+        headers: { get: () => null }
+      })
+
+      const okResponse = (body = '{}') => ({
+        ok: true,
+        headers: { get: () => null },
+        text: () => Promise.resolve(body)
+      })
+
+      test('should retry via fetch when the response is not ok', async () => {
+        global.fetch = jest.fn().mockResolvedValue(failedResponse())
+
+        RequestDispatcher.handleFetchResponse('http://x.com?d=abc', 'http://x.com?d=abc')
+        await flushPromises()
+
+        expect(global.fetch).toHaveBeenCalledTimes(1)
+        expect(RequestDispatcher.logger.error).toHaveBeenCalledWith('Network response was not ok', expect.any(Error))
+
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+        await flushPromises()
+
+        expect(global.fetch).toHaveBeenCalledTimes(2)
+        expect(global.fetch).toHaveBeenNthCalledWith(2, 'http://x.com?d=abc', expect.any(Object))
+      })
+
+      test('should keep retrying across multiple consecutive network failures', async () => {
+        global.fetch = jest.fn().mockResolvedValue(failedResponse())
+
+        RequestDispatcher.handleFetchResponse('http://x.com?d=abc', 'http://x.com?d=abc')
+        await flushPromises()
+
+        for (let i = 0; i < 3; i++) {
+          jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+          await flushPromises()
+        }
+
+        expect(global.fetch).toHaveBeenCalledTimes(4)
+      })
+
+      test('should stop retrying once a subsequent attempt succeeds', async () => {
+        global.fetch = jest.fn()
+          .mockResolvedValueOnce(failedResponse())
+          .mockResolvedValueOnce(okResponse())
+
+        RequestDispatcher.handleFetchResponse('http://x.com?d=abc', 'http://x.com?d=abc')
+        await flushPromises()
+
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+        await flushPromises()
+        expect(global.fetch).toHaveBeenCalledTimes(2)
+
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+        await flushPromises()
+        // no further retry scheduled after a successful response
+        expect(global.fetch).toHaveBeenCalledTimes(2)
+      })
+
+      test('should not retry for a 402/419 (encryption disabled) response - it falls back to JSONP instead', async () => {
+        global.fetch = jest.fn().mockResolvedValue(failedResponse(419, 'Encryption not enabled'))
+        document.getElementsByClassName = jest.fn().mockReturnValue([])
+        document.createElement = jest.fn().mockReturnValue({ setAttribute: jest.fn(), async: true })
+        document.getElementsByTagName = jest.fn().mockReturnValue([{ appendChild: jest.fn() }])
+
+        RequestDispatcher.handleFetchResponse('http://x.com?d=encrypted', 'http://x.com?d=original')
+        await flushPromises()
+
+        jest.advanceTimersByTime(MAX_RETRY_DELAY_MS)
+        await flushPromises()
+
+        // still only the original call - the retry went via JSONP, not another fetch
+        expect(global.fetch).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/test/unit/util/url.spec.js
+++ b/test/unit/util/url.spec.js
@@ -36,6 +36,11 @@ describe('util/url', function () {
       const value = getURLParam(url, param)
       expect(value).toBe(expectedValue)
     })
+
+    test('should match the complete parameter name', () => {
+      const value = getURLParam('?wzrk_rn=9&rn=3', 'rn')
+      expect(value).toBe('3')
+    })
   })
 
   describe('get domain', () => {

--- a/test/unit/util/url.spec.js
+++ b/test/unit/util/url.spec.js
@@ -2,7 +2,8 @@ import {
   addToURL,
   getDomain,
   getHostName,
-  getURLParams
+  getURLParams,
+  getURLParam
 } from '../../../src/util/url'
 
 describe('util/url', function () {
@@ -21,6 +22,19 @@ describe('util/url', function () {
         bar: 'test user'
       }
       expect(urlParams).toMatchObject(expectedObject)
+    })
+  })
+
+  describe('get url param', () => {
+    test('should return empty string when url is empty string', () => {
+      const param = getURLParam('', 'foo')
+      expect(param).toBe('')
+    })
+
+    test.each([['foo', 'abc'], ['bar', 'test user']])('should return urlParam for given param name', (param, expectedValue) => {
+      const url = 'www.example.com/test?foo=abc&bar=test+user'
+      const value = getURLParam(url, param)
+      expect(value).toBe(expectedValue)
     })
   })
 


### PR DESCRIPTION
### Changes

Jira Issue: ONC-654

This PR adds an exponential backoff retry mechanism for failed network requests, along with several related fixes to the backup/event-dispatch flow:

- **Exponential backoff retry** added in `src/util/requestDispatcher.js` for failed network requests, with fallback handling when retries are exhausted.
- **Opt-out handling in `RequestManager`** (`src/modules/request.js`): new `#dropRequestDueToOptOut()` method drops requests when the opt-out cookie condition is met, and clears/removes stored backup requests that are blocked by mute or opt-out settings.
- **Malformed backup event cleanup**: `processBackupEvents()` now removes malformed backup entries (via `StorageManager.removeBackup`) instead of leaving them stuck in storage, and the `oulOnly` param doc/behavior was corrected to reflect "process all backup requests" rather than "non-fired requests."
- **Removed the old polling-based backup trigger** in `src/clevertap.js` (the `setInterval` loop to call `processBackupEvents()`), since backup processing is now handled through the new retry/dispatch flow.
- **URL utility improvement** in `src/util/url.js` — added support for extracting individual URL parameters.
- Unit tests added/updated for `request.js`, `requestDispatcher.js`, and `url.js`.

### Changes to Public Facing API if any 

None — changes are internal to request dispatching, backup processing, and opt-out handling. No public method signatures appear to be added, removed, or changed.

### How Has This Been Tested?

Covered by new/updated unit tests:
- `test/unit/modules/request.spec.js` — backup event processing, malformed event removal, opt-out request dropping
- `test/unit/util/requestDispatcher.spec.js` — exponential backoff retry and fallback behavior
- `test/unit/util/url.spec.js` — individual URL parameter extraction

Further, local testing has been done on browser via fetch as well as script (JSONP)

### Checklist

- [ ] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [ ] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of backed-up events, including removal of malformed entries.
  * Requests are now correctly dropped when opt-out settings apply.
  * Added automatic retries for failed network requests, with exponential backoff and fallback handling.
  * Cleared stored requests when they are blocked by mute or opt-out settings.

* **Improvements**
  * Added support for extracting individual URL parameters.
  * Improved reliability when processing network and encryption-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->