### PR TITLE
Raise per-slide Notification Viewed for web native display carousels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [3.0.4] 9th September 2026
+- Raise Notification Viewed event per carousel slide in Web Native Display.
+
 ## [3.0.3] 7th September 2026
 - Fixed the frequency capping logic.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-web-sdk",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "",
   "main": "dist/clevertap.js",
   "files": [

--- a/src/util/web-personalisation/carousel.js
+++ b/src/util/web-personalisation/carousel.js
@@ -59,7 +59,6 @@ export class CTWebPersonalisationCarousel extends HTMLElement {
     // TODO: enable conditionally
     this.startAutoSlide()
     this.setupOnHover()
-    window.clevertap.renderNotificationViewed({ msgId: this.target.wzrk_id, pivotId: this.target.wzrk_pivot })
   }
 
   setupClick () {

--- a/src/util/web-personalisation/carousel.js
+++ b/src/util/web-personalisation/carousel.js
@@ -1,4 +1,8 @@
 import { CTWebPersonalisationBanner } from './banner'
+import { CampaignContext } from '../campaignHouseKeeping/campaignContext'
+
+const SLIDE_VIEWED_KEY = 'WZRK_WND_CAROUSEL_SLIDE_VIEWED'
+
 export class CTWebPersonalisationCarousel extends HTMLElement {
   constructor () {
     super()
@@ -16,6 +20,7 @@ export class CTWebPersonalisationCarousel extends HTMLElement {
   selectedItem = 1
   autoSlide = null
   stopAutoSlideTimeout = null
+  viewedSlides = new Set()
 
   get target () {
     return this._target || ''
@@ -158,6 +163,59 @@ export class CTWebPersonalisationCarousel extends HTMLElement {
     item.classList.add('carousel__item--selected')
     if (button) {
       button.classList.add('carousel__button--selected')
+    }
+    this.raiseSlideViewed(this.selectedItem)
+  }
+
+  getSessionId () {
+    return CampaignContext.session?.sessionId || 'session'
+  }
+
+  getViewedSlideStore () {
+    try {
+      const raw = sessionStorage.getItem(SLIDE_VIEWED_KEY)
+      const parsed = raw ? JSON.parse(raw) : {}
+      return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch (e) { 
+      return {}
+    } // sessionStorage may be unavailable
+  }
+
+  hasSlideBeenViewed (slideNo) {
+    if (this.viewedSlides.has(slideNo)) return true
+    const sessionId = this.getSessionId()
+    const msgId = this.target?.wzrk_id
+    const slides = this.getViewedSlideStore()?.[sessionId]?.[msgId]
+    return Array.isArray(slides) && slides.includes(slideNo)
+  }
+
+  markSlideViewed (slideNo) {
+    this.viewedSlides.add(slideNo)
+    const msgId = this.target?.wzrk_id
+    if (!msgId) return
+    try {
+      const sessionId = this.getSessionId()
+      const bySession = this.getViewedSlideStore()?.[sessionId] || {}
+      const slides = new Set(bySession[msgId] || [])
+      slides.add(slideNo)
+      sessionStorage.setItem(SLIDE_VIEWED_KEY, JSON.stringify({
+        [sessionId]: { ...bySession, [msgId]: [...slides] }
+      }))
+    } catch (e) {
+      // sessionStorage may be unavailable
+    }
+  }
+
+  raiseSlideViewed (slideNo) {
+    if (!slideNo || !this.target?.wzrk_id || this.hasSlideBeenViewed(slideNo)) return
+    const payload = {
+      msgId: this.target.wzrk_id,
+      pivotId: this.target.wzrk_pivot,
+      wzrk_slideNo: slideNo
+    }
+    if (window.clevertap?.renderNotificationViewed) {
+      window.clevertap.renderNotificationViewed(payload)
+      this.markSlideViewed(slideNo)
     }
   }
 

--- a/src/util/web-personalisation/carousel.js
+++ b/src/util/web-personalisation/carousel.js
@@ -180,18 +180,25 @@ export class CTWebPersonalisationCarousel extends HTMLElement {
     } // sessionStorage may be unavailable
   }
 
-  hasSlideBeenViewed (slideNo) {
-    if (this.viewedSlides.has(slideNo)) return true
+  getSlideViewedKey (slideNo) {
     const sessionId = this.getSessionId()
     const msgId = this.target?.wzrk_id
+    return `${sessionId}:${msgId}:${slideNo}`
+  }
+
+  hasSlideBeenViewed (slideNo) {
+    const msgId = this.target?.wzrk_id
+    if (!msgId) return false
+    if (this.viewedSlides.has(this.getSlideViewedKey(slideNo))) return true
+    const sessionId = this.getSessionId()
     const slides = this.getViewedSlideStore()?.[sessionId]?.[msgId]
     return Array.isArray(slides) && slides.includes(slideNo)
   }
 
   markSlideViewed (slideNo) {
-    this.viewedSlides.add(slideNo)
     const msgId = this.target?.wzrk_id
     if (!msgId) return
+    this.viewedSlides.add(this.getSlideViewedKey(slideNo))
     try {
       const sessionId = this.getSessionId()
       const bySession = this.getViewedSlideStore()?.[sessionId] || {}

--- a/test/unit/util/web-personalisation/carousel.spec.js
+++ b/test/unit/util/web-personalisation/carousel.spec.js
@@ -111,4 +111,16 @@ describe('web native display carousel notification viewed', function () {
       { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 1 }
     ])
   })
+
+  test('raises slide viewed again on existing carousel after session change', () => {
+    const carousel = mountCarousel()
+    window.clevertap.renderNotificationViewed.mockClear()
+
+    CampaignContext._session = { sessionId: 'session-2' }
+    carousel.raiseSlideViewed(1)
+
+    expect(slideViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 1 }
+    ])
+  })
 })

--- a/test/unit/util/web-personalisation/carousel.spec.js
+++ b/test/unit/util/web-personalisation/carousel.spec.js
@@ -58,12 +58,10 @@ describe('web native display carousel notification viewed', function () {
     CampaignContext._session = null
   })
 
-  test('raises campaign viewed and first slide viewed on render', () => {
+  test('raises first slide viewed on render', () => {
     mountCarousel()
 
-    expect(campaignViewedCalls()).toEqual([
-      { msgId: 'campaign_1', pivotId: 'pivot_1' }
-    ])
+    expect(campaignViewedCalls()).toEqual([])
     expect(slideViewedCalls()).toEqual([
       { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 1 }
     ])
@@ -99,9 +97,7 @@ describe('web native display carousel notification viewed', function () {
     mountCarousel()
 
     expect(slideViewedCalls()).toEqual([])
-    expect(campaignViewedCalls()).toEqual([
-      { msgId: 'campaign_1', pivotId: 'pivot_1' }
-    ])
+    expect(campaignViewedCalls()).toEqual([])
   })
 
   test('raises slide viewed again for a new session', () => {

--- a/test/unit/util/web-personalisation/carousel.spec.js
+++ b/test/unit/util/web-personalisation/carousel.spec.js
@@ -1,0 +1,118 @@
+import { CTWebPersonalisationCarousel } from '../../../../src/util/web-personalisation/carousel'
+import { CampaignContext } from '../../../../src/util/campaignHouseKeeping/campaignContext'
+
+if (customElements.get('ct-web-personalisation-carousel') === undefined) {
+  customElements.define('ct-web-personalisation-carousel', CTWebPersonalisationCarousel)
+}
+
+const buildTarget = () => ({
+  wzrk_id: 'campaign_1',
+  wzrk_pivot: 'pivot_1',
+  display: {
+    details: [
+      { desktopImageURL: 'slide-1.jpg', mobileImageURL: 'slide-1-m.jpg', onClick: '' },
+      { desktopImageURL: 'slide-2.jpg', mobileImageURL: 'slide-2-m.jpg', onClick: '' },
+      { desktopImageURL: 'slide-3.jpg', mobileImageURL: 'slide-3-m.jpg', onClick: '' }
+    ],
+    showNavBtns: false,
+    showNavArrows: false,
+    navBtnsCss: '',
+    navArrowsCss: '',
+    sliderTime: 30
+  }
+})
+
+const slideViewedCalls = () => {
+  return window.clevertap.renderNotificationViewed.mock.calls
+    .map((call) => call[0])
+    .filter((payload) => payload && payload.wzrk_slideNo)
+}
+
+const campaignViewedCalls = () => {
+  return window.clevertap.renderNotificationViewed.mock.calls
+    .map((call) => call[0])
+    .filter((payload) => payload && payload.msgId && !payload.wzrk_slideNo)
+}
+
+const mountCarousel = () => {
+  const carousel = document.createElement('ct-web-personalisation-carousel')
+  carousel.target = buildTarget()
+  return carousel
+}
+
+describe('web native display carousel notification viewed', function () {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    sessionStorage.clear()
+    CampaignContext._session = { sessionId: 'session-1' }
+    window.clevertap = {
+      renderNotificationViewed: jest.fn(),
+      renderNotificationClicked: jest.fn()
+    }
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+    sessionStorage.clear()
+    CampaignContext._session = null
+  })
+
+  test('raises campaign viewed and first slide viewed on render', () => {
+    mountCarousel()
+
+    expect(campaignViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1' }
+    ])
+    expect(slideViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 1 }
+    ])
+  })
+
+  test('raises viewed for a newly shown slide with that slide number', () => {
+    const carousel = mountCarousel()
+    window.clevertap.renderNotificationViewed.mockClear()
+
+    carousel.goToNext()
+
+    expect(slideViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 2 }
+    ])
+    expect(campaignViewedCalls()).toEqual([])
+  })
+
+  test('does not raise viewed again for a slide already seen in the same session', () => {
+    const carousel = mountCarousel()
+    carousel.goToNext()
+    window.clevertap.renderNotificationViewed.mockClear()
+
+    carousel.goToPrev()
+    carousel.goToNext()
+
+    expect(slideViewedCalls()).toEqual([])
+  })
+
+  test('does not raise slide viewed again when carousel is rendered again in the same session', () => {
+    mountCarousel()
+    window.clevertap.renderNotificationViewed.mockClear()
+
+    mountCarousel()
+
+    expect(slideViewedCalls()).toEqual([])
+    expect(campaignViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1' }
+    ])
+  })
+
+  test('raises slide viewed again for a new session', () => {
+    mountCarousel()
+    CampaignContext._session = { sessionId: 'session-2' }
+    window.clevertap.renderNotificationViewed.mockClear()
+
+    mountCarousel()
+
+    expect(slideViewedCalls()).toEqual([
+      { msgId: 'campaign_1', pivotId: 'pivot_1', wzrk_slideNo: 1 }
+    ])
+  })
+})


### PR DESCRIPTION
Track each slide once per session and include wzrk_slideNo so image and text-with-image carousels can be measured separately.

JIRA Issue: JIRA_TICKET_ID

### Changes

Describe the key changes in this PR with the Jira Issue reference 

### Changes to Public Facing API if any 

Please list the impact on the public facing API if any

### How Has This Been Tested?

Describe the testing approach and any relevant configurations (e.g., environment, platform)

### Checklist

- [ ] Code compiles without errors
- [ ] Version Bump added to package.json & CHANGELOG.md
- [ ] All tests pass
- [ ] Build process is successful
- [ ] Documentation has been updated (if needed)
- [ ] Automation tests are passing

### Link to Deployed SDK 

Use these url for testing : 
1. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/clevertap.min.js`  
2. `https://static.wizrocket.com/staging/<CURRENT_BRANCH_NAME>/js/sw_webpush.min.js`

### How to trigger Automations

Just add a empty commit after all your changes are done in the PR with the command 

```bash
 git commit --allow-empty -m "[run-test] Testing Automation"
```

This will trigger the [automation](https://github.com/Clevertap/ct-web-sdk-automation/actions) suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Carousel slide views are now tracked per session.
  * Viewed-slide notifications are sent only once for each slide during a session, including when the carousel is rendered again.
  * New sessions can generate fresh slide-view notifications.

* **Tests**
  * Added coverage for first-slide tracking, navigation to new slides, repeat rendering, and tracking across separate sessions.

* **Documentation**
  * Updated release information for version 3.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->